### PR TITLE
added the @all-contributors functionality

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,3 @@
+{
+  "projectName": "UnfoldBIDS.jl",
+  "projectOwner": "unfoldtoolbox",

--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ You are very welcome to raise issues and start pull requests!
 - **Benedikt Ehinger**
 - **René Skukies**
 
+## Contributors List
+
+## Contributors
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+
+This project follows the [all-contributors](https://allcontributors.org/docs/en/specification) specification. 
+
+Contributions of any kind welcome!
+You can find the emoji key for the contributors [here](https://github.com/unfoldtoolbox/Unfold.jl/blob/main/docs/contrib-emoji.md)
+
+
 ## Citation
 
 ## Acknowledgements


### PR DESCRIPTION
All contributors should be added as a comment in a pull request or an issue.
Eg : @all-contributors please add @behinger for <contributions>

<contributions> can be test, code as given in the emoji key
